### PR TITLE
Redirect authenticated users from homepage to dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,13 @@
 import Image from "next/image";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function Home() {
+export default async function Home() {
+  const { userId } = await auth();
+
+  if (userId) {
+    redirect("/dashboard");
+  }
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">


### PR DESCRIPTION
When a logged-in user accesses the main homepage (/), they are now automatically redirected to /dashboard. This improves the user experience by taking authenticated users directly to their dashboard instead of showing them the public landing page.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)